### PR TITLE
Fix PKCE's URL-safe Base64 encoding

### DIFF
--- a/src/flow/pkce.html
+++ b/src/flow/pkce.html
@@ -128,8 +128,8 @@
             const data = encoder.encode(verifier);
             const digest = await crypto.subtle.digest('SHA-256', data);
             const base64UrlEncoded = btoa(String.fromCharCode(...new Uint8Array(digest)))
-                .replace('+', '-')
-                .replace('/', '_')
+                .replaceAll('+', '-')
+                .replaceAll('/', '_')
                 .replace(/=+$/, '');
 
             $('#codeChallenge').val(base64UrlEncoded);


### PR DESCRIPTION
Bertík just got bit by this. He didn't notice that the challenge was incorrectly encoded and was wondering why his PKCE implementation didn't work. Very sad.

![obrazek](https://github.com/ysoftdevs/oauth-playground-client/assets/1297565/924fd4b6-e007-4d3b-add3-bc0dcd73f695)
